### PR TITLE
Use string for the discriminator property instead of int

### DIFF
--- a/voltage/types/user.py
+++ b/voltage/types/user.py
@@ -27,7 +27,7 @@ class UserRelationPayload(TypedDict):
 class UserPayload(TypedDict):
     _id: str
     username: str
-    discriminator: int
+    discriminator: str
     avatar: NotRequired[FilePayload]
     bot: NotRequired[UserBotPayload]
     relations: NotRequired[List[UserRelationPayload]]

--- a/voltage/user.py
+++ b/voltage/user.py
@@ -74,7 +74,7 @@ class User(Messageable):
         The epoch time when the user was created.
     name: :class:`str`
         The user's name.
-    discriminator: :class:`int`
+    discriminator: :class:`str`
         The user's discriminator.
     avatar: :class:`Asset`
         The user's avatar.
@@ -123,7 +123,7 @@ class User(Messageable):
         self.created_at = ULID().decode(self.id)[0]
 
         self.name = data["username"]
-        self.discriminator = int(data["discriminator"])
+        self.discriminator = data["discriminator"]
         self.dm_channel = cache.get_dm_channel(self.id)
         self.flags = data.get("flags", 0)
         self.badges = UserFlags.new_with_flags(self.flags)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Apparantly the reason why the Revolt API uses the string type for discriminators its because if we use an integer then for example `searinminecraft#0420` would become `searinminecraft#420`. so this pr fixes it :trollface: 

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, …)
