### PR TITLE
Fix badges attribute for the User class

### DIFF
--- a/voltage/flag.py
+++ b/voltage/flag.py
@@ -205,3 +205,12 @@ class UserFlags(FlagBase):
         Whether the user has the relevant joke 1 (amogus) badge.
         """
         return 1 << 9
+
+    @FlagValue
+    def reserved_relevant_joke_badge_2(self):
+        """
+        Whether the user has the relevant joke 2 (amorbus) badge.
+        """
+
+        return 1 << 10
+

--- a/voltage/user.py
+++ b/voltage/user.py
@@ -126,7 +126,7 @@ class User(Messageable):
         self.discriminator = data["discriminator"]
         self.dm_channel = cache.get_dm_channel(self.id)
         self.flags = data.get("flags", 0)
-        self.badges = UserFlags.new_with_flags(self.flags)
+        self.badges = UserFlags.new_with_flags(data.get("badges", 0))
         self.online = data.get("online", False)
 
         avatar = data.get("avatar")


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

The `flag` property in the API is no longer used to determine the user's badges, resulting in the library thinking the user has no badges. Instead, it uses the `badges` property. This PR will make it use the `badges` property instead of `flags`

Heres an example for a user with badges (i used pprint to pretty print it):

```
{'_id': '01F1WKM5TK2V6KCZWR6DGBJDTZ',
 'avatar': {'_id': '1XpKpyqGvJ5BBl6uNfg5DBd0Nliyf4KVbtRH4pmLnZ',
            'content_type': 'image/png',
            'filename': 'sJ0lsZxzlYTyxC3HVzogea9LKlCVwtpvYMNZIFVA_k.png',
            'metadata': {'height': 410, 'type': 'Image', 'width': 411},
            'size': 343493,
            'tag': 'avatars'},
 'badges': 1807,
 'discriminator': '6328',
 'display_name': 'Jennifer',
 'online': False,
 'relationship': 'None',
 'status': {'presence': 'Focus', 'text': 'dandori issue'},
 'username': 'Infi'}
```

This also adds the relevant joke 2 badge (amorbus) in the UserFlags class, which was previously missing.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, …)
