### PR TITLE
fix: allow users to be mentioned

### DIFF
--- a/voltage/ext/commands/converters.py
+++ b/voltage/ext/commands/converters.py
@@ -54,7 +54,7 @@ class FloatConverter(Converter):
         return float(arg)
 
 
-id_regex = compile(r"[0-9A-HJ-KM-NP-TV-Z]{26}")
+id_regex = compile(r"<?@?([0-9A-HJ-KM-NP-TV-Z]{26})>?")
 
 
 class UserConverter(Converter):


### PR DESCRIPTION
 instead of having to use ids, mention the user! this also supports @USERIDHERE instead of <@USERIDHERE> :)

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
it fixes the issue of not being able to mention a user to set a `voltage.User` argument
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
    - [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, …)
