### PR TITLE
fix: initialize aiohttp client only at startup

### DIFF
--- a/voltage/client.py
+++ b/voltage/client.py
@@ -60,7 +60,7 @@ class Client:
 
     def __init__(self, *, cache_message_limit: int = 5000):
         self.cache_message_limit = cache_message_limit
-        self.client = aiohttp.ClientSession()
+        self.client = None
         self.http: HTTPHandler
         self.ws: WebSocketHandler
         self.listeners: Dict[str, Callable[..., Any]] = {}
@@ -252,6 +252,7 @@ class Client:
         banner: :class:`bool`
             Whether or not to print startup banner.
         """
+        self.client = aiohttp.ClientSession()
         self.http = HTTPHandler(self.client, token, bot=bot)
         self.cache = CacheHandler(self.http, self.loop, self.cache_message_limit)
         self.ws = WebSocketHandler(self.client, self.http, self.cache, token, self.dispatch, self.raw_dispatch)


### PR DESCRIPTION
## Summary

Create's the ClientSession inside of the start function instead of the initializer function.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
    - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, …)
